### PR TITLE
Add option to archive charts to card

### DIFF
--- a/bin/ivanello
+++ b/bin/ivanello
@@ -19,6 +19,8 @@ program
   .option('--sprint-name <string>', 'The name of the sprint', 'Infinity')
   .option('--end-date <string>', 'E.g. "Jan 1 2015"')
   .option('--silent <bool>', 'Toggle output logging', false)
+  .option('--archive <bool>', 'Toggle output archiving', false)
+  .option('--archive-card <bool>', 'Card to archive to', 'Burndown')
   .parse(process.argv);
 
 if(program.datafile && fs.existsSync(path.join(saveLoc, program.datafile))) {
@@ -65,6 +67,12 @@ var makeSite = function(cb) {
     cb(null);
 };
 
+var archiveSite = function(cb) {
+  return program.archive ? 
+    require('../lib/archive.js')(program, cb) :
+    cb(null);
+};
+
 var finish = function(err) {
   if(err) { throw err; }
   if(!program.silent) {
@@ -76,6 +84,7 @@ async.series([
   saveData,
   updateLists,
   updateData,
-  makeSite
+  makeSite,
+  archiveSite
 ], finish);
 

--- a/lib/archive.js
+++ b/lib/archive.js
@@ -1,0 +1,35 @@
+module.exports = function(opts, cb) {
+
+    'use strict';
+
+    console.log('Running archive script');
+
+    var async = require('async'),
+        Trello = require('node-trello'),
+        trelloUtils = require('../lib/trelloUtils.js'),
+        trello = new Trello(opts.apiKey, opts.token);
+
+    var boardId = opts.boardUrl
+                      .replace(/.*\/b\//, '')
+                      .replace(/\/.*$/, '');
+
+    var doArchive = function(cardId, cb) {
+        async.waterfall([
+            trelloUtils.addAttachmentToCard(trello, cardId, './charts.html', 'Burndown Chart.html', 'text/html'),
+            trelloUtils.addAttachmentToCard(trello, cardId, './burndown.json', 'Burndown Data.json', 'application/json')
+        ], function(err, result) {
+            if(err) { return cb(err); }
+            return cb(null);
+        });
+    };
+
+    async.waterfall([
+        trelloUtils.getBoardCardIdByName(trello, boardId, opts.archiveCard),
+        doArchive
+    ], function(err, result) {
+        if(err) { return cb(err); }
+        return cb(null);        
+    });
+
+
+};

--- a/lib/trelloUtils.js
+++ b/lib/trelloUtils.js
@@ -1,0 +1,95 @@
+var format = require('util').format,
+    path = require('path'),
+    fs = require('fs');
+
+module.exports = {
+
+  /**
+   * Returns the id of list name in the given board.
+   * @param  {Trello} Trello object
+   * @param  {string} Board id
+   * @param  {string} List name
+   * @param  {function} Callback
+   */
+  getBoardListIdByName: function(t, boardId, listName, cb) {
+    return function(cb) {
+      var listNameLowerCase = listName.toLowerCase();
+      t.get(format('/1/boards/%s/lists', boardId), function(err, lists) {
+        if(err) {return cb(err);}
+        var ix;
+        for(ix = lists.length; ix--;) {
+          if(lists[ix].name.toLowerCase() === listNameLowerCase) {
+            return cb(null, lists[ix].id);
+          }
+        }
+        cb(new Error(format('Could not find a list %s in board %s.', listNameLowerCase, boardId)));
+      });
+    };
+  },
+
+  /**
+   * Returns the id of list name in the given card.
+   * @param  {Trello} Trello object
+   * @param  {string} Board id
+   * @param  {string} Card name
+   * @param  {function} Callback
+   */
+  getBoardCardIdByName: function(t, boardId, cardName, cb) {
+    return function(cb) {
+      var cardNameLowerCase = cardName.toLowerCase();
+      t.get(format('/1/boards/%s/cards', boardId), function(err, lists) {
+        if(err) {return cb(err);}
+        var ix;
+        for(ix = lists.length; ix--;) {
+          if(lists[ix].name.toLowerCase() === cardNameLowerCase) {
+            return cb(null, lists[ix].id);
+          }
+        }
+        cb(new Error(format('Could not find a list %s in board %s.', cardNameLowerCase, boardId)));
+      });
+    };
+  },
+
+  /**
+   * Post an attachment to the given card.
+   * 
+   * @param  {Trello} Trello object
+   * @param  {string} Card id
+   * @param  {string} Path to file to attach
+   * @param  {string} Name of attachment on card
+   * @param  {string} Mime type of the file
+   * @param  {function} Callback
+   * @return {function}
+   */
+  addAttachmentToCard: function(t, cardId, filePath, attachmentName, mimeType, cb) {
+    return function(cb) {
+      fs.readFile(filePath, 'utf8', function(err, data) {
+        if(err) { return cb(err); }
+        t.post(format('/1/cards/%s/attachments', cardId), {file: data, name: attachmentName, mimeType: mimeType}, function(err, lists) {
+          if(err) { return cb(err); }
+          return cb(null);
+        });  
+      });      
+    };
+  },
+
+  /**
+   * Post an attachment to the given card.
+   * 
+   * @param  {Trello} Trello object
+   * @param  {string} Card id
+   * @param  {string} Path to file to attach
+   * @param  {string} Name of attachment on card
+   * @param  {string} Mime type of the file
+   * @param  {function} Callback
+   * @return {function}
+   */
+  deleteAttachmentsFromCard: function(t, cardId, attachmentId) {
+    return function(cb) {
+      t.del(format('/1/cards/%s/attachments/%s', cardId, attachmentId), function(err, lists) {
+        if(err) { return cb(err); }
+        return cb(null);
+      });    
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "handlebars": "^2.0.0",
     "lodash.after": "^2.4.1",
     "lodash.clone": "^3.0.1",
-    "request": "^2.48.0"
+    "request": "^2.48.0",
+    "node-trello": "^1.1.0"
   }
 }


### PR DESCRIPTION
Enable the "archive" option to post the constructed chart/data files
back to Trello. Does not remove any attachments from the card, so will
attach dupes if run multiple times.

@jtrussell Requires use of a token that allows **read/write** access.
